### PR TITLE
Fix error regex

### DIFF
--- a/autoload/exception.vim
+++ b/autoload/exception.vim
@@ -56,7 +56,7 @@ function! exception#trace() abort
         continue
       endif
 
-      let src = fnamemodify(matchstr(verb[1], 'Last set from \zs.\+'), ':p')
+      let src = fnamemodify(matchstr(verb[1], 'Last set from \zs.\+\ze\%( line \d\+\)'), ':p')
       if !filereadable(src)
         continue
       endif


### PR DESCRIPTION
Seems like Vim's output has changed to include the line number in the same line. This regex seems to work on my machine, and I've left the group optional for older versions.