### PR TITLE
Show error line body

### DIFF
--- a/autoload/exception.vim
+++ b/autoload/exception.vim
@@ -56,7 +56,7 @@ function! exception#trace() abort
         continue
       endif
 
-      let src = fnamemodify(matchstr(verb[1], 'Last set from \zs.\+'), ':p')
+      let src = fnamemodify(matchstr(verb[1], 'Last set from \zs.\+\ze\%( line \d\+\)'), ':p')
       if !filereadable(src)
         continue
       endif


### PR DESCRIPTION
This shows the text of the line that error out, and not just the function + line. I feel like it would be useful to see the actual code that blew up:

```
|| OK
test.vim|3 info| #0. Test1[2]: echoerr "OK"
test.vim|9 info| #1. Test2[2]: call Test1()
```